### PR TITLE
Flatten children to support mixing hardcoded elements and lists arbitrarily

### DIFF
--- a/src/ReactElementAdapter.js
+++ b/src/ReactElementAdapter.js
@@ -54,6 +54,14 @@ function isValidChild(child) {
     );
 }
 
+function flatten(value) {
+    if (!Array.isArray(value)) {
+        return [value];
+    }
+
+    return value.reduce((result, item) => result.concat(flatten(item)), [])
+}
+
 class ReactElementAdapter {
 
     constructor(options) {
@@ -92,6 +100,7 @@ class ReactElementAdapter {
 
     getChildren(element) {
 
+        var children = element.props.children;
         var childrenArray = [];
         var iteratorFn;
 
@@ -102,12 +111,12 @@ class ReactElementAdapter {
         // https://github.com/facebook/react/blob/35962a00084382b49d1f9e3bd36612925f360e5b/src/shared/utils/traverseAllChildren.js
         // with the exception that we remove the nulls
         // Basically strings & numbers && elements are allowed (elements classed as objects & functions for simplicity)
-        if (Array.isArray(element.props.children)) {
-            childrenArray = childrenArray.concat(element.props.children).filter(child => isValidChild(child));
-        } else if (isValidChild(element.props.children)) {
-            childrenArray = [ element.props.children ];
-        } else if (iteratorFn = getIteratorFn(element.props.children)) {
-            const iterator = iteratorFn.call(element.props.children);
+        if (Array.isArray(children)) {
+            childrenArray = flatten(children).filter(child => isValidChild(child));
+        } else if (isValidChild(children)) {
+            childrenArray = [ children ];
+        } else if (iteratorFn = getIteratorFn(children)) {
+            const iterator = iteratorFn.call(children);
             let step;
 
             while (!(step = iterator.next()).done) {

--- a/src/tests/ReactElementAdapter.spec.jsx
+++ b/src/tests/ReactElementAdapter.spec.jsx
@@ -293,6 +293,39 @@ describe('ReactElementAdapter', () => {
                 <span>three</span>
             ]);
         });
+
+        it('flattens the children', () => {
+            const list = [
+                <span>one</span>,
+                <span>two</span>,
+                [
+                    <span>three</span>,
+                    <span>Four</span>,
+                    <span>Five</span>,
+                    [
+                        <span>Six</span>,
+                        <span>Seven</span>
+                    ],
+                    <span>Eight</span>
+                ],
+                <span>Nine</span>,
+                <span>Ten</span>
+            ];
+
+            const component = <span>{list}</span>;
+            expect(adapter.getChildren(component), 'to equal', [
+                <span>one</span>,
+                <span>two</span>,
+                <span>three</span>,
+                <span>Four</span>,
+                <span>Five</span>,
+                <span>Six</span>,
+                <span>Seven</span>,
+                <span>Eight</span>,
+                <span>Nine</span>,
+                <span>Ten</span>
+            ]);
+        })
     });
 
     it('returns the correct classAttributeName', () => {


### PR DESCRIPTION
This seems  to fix this failing test case in unexpected-react: https://github.com/bruderstein/unexpected-react/pull/8

If I package the lib with `npm pack` and unpack it in unexpected-react node_modules all tests passes.
